### PR TITLE
Support RequireJS

### DIFF
--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -96,7 +96,7 @@ HTTPSServer.prototype.expose = function(obj, namespace, name){
   // buffer module object
   } else if (this._require) {
     obj = 'module.exports = ' + string(obj);
-    this.expose(renderRegister(namespace, obj), name);
+    this.expose(renderRegister(namespace, obj, this._rjs), name);
   // buffer object
   } else {
     this.expose(renderNamespace(namespace), name);
@@ -110,17 +110,26 @@ HTTPSServer.prototype.expose = function(obj, namespace, name){
 /**
  * Expose the common-js module system to the client-side.
  *
+ * @param {Boolean} rjs
  * @return {HTTPServer} for chaining
  * @api public
  */
 
 res.exposeRequire =
 HTTPServer.prototype.exposeRequire =
-HTTPSServer.prototype.exposeRequire = function(){
+HTTPSServer.prototype.exposeRequire = function(rjs){
   if (this._require) return this;
   this._require = true;
-  var js = fs.readFileSync(__dirname + '/require.js', 'ascii');
-  this.expose(js);
+
+  if (!rjs) {
+    var js = fs.readFileSync(__dirname + '/require.js', 'ascii');
+    this.expose(js);
+  
+    this._rjs = false;
+  }else{
+    this._rjs = true;
+  }
+
   return this;
 };
 
@@ -144,7 +153,7 @@ HTTPSServer.prototype.exposeModule = function(path, namespace, name){
     , namespace = namespace || basename(path, extname(path));
 
   if (this._require) {
-    this.expose(renderRegister(namespace, js), name);
+    this.expose(renderRegister(namespace, js, this._rjs), name);
   } else {
     js = namespace
       + ' = (function(exports){\n'
@@ -181,17 +190,23 @@ HTTPSServer.prototype.exposed = function(name){
  *
  * @param {String} mod
  * @param {String} js
+ * @param {Boolean} rjs
  * @return {String}
  * @api private
  */
 
-function renderRegister(mod, js) {
-  return 'require.register("'
-    + mod + '", function(module, exports, require){\n'
-    + js + '\n});';
+function renderRegister(mod, js, rjs) {
+  if (rjs) {
+    return 'define("'
+      + mod + '", function(require, exports, module){\n'
+      + js + '\n});';
+  }else{
+    return 'require.register("'
+      + mod + '", function(module, exports, require){\n'    
+  }
 }
 
-/**
+/*
  * Render a namespace from the given `str`.
  *
  * Examples:

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   , "keywords": ["express"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "devDependencies": {
-      "connect": "1.4.x"
-    , "express": "2.3.x"
+      "connect": ">= 1.4.x"
+    , "express": ">= 2.3.x"
     , "expresso": ">= 0.0.1"
     , "should": ">= 0.0.1"
     , "jade": ">= 0.0.1"
   }
   , "main": "index"
-  , "engines": { "node": "0.4.x" }
+  , "engines": { "node": ">= 0.4.x < 0.7.0" }
 }


### PR DESCRIPTION
on Client-Side,
express-expose require() is not work with RequireJS.

Server-Side:

```
app.exposeRequire(true)
```

Client-Side (jade):

```
script(src='/js/libs/require.js', data-main='/js/main')
script!= javascript
```

I tried to write test. 

but it has already didn't working on Node 0.4.12 and Node 0.6.x.
