### PR TITLE
Make it possible to expose application level variables as separate files...

### DIFF
--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -280,6 +280,6 @@ HTTPSServer.prototype.exposeBundles = function(before, after){
     	    after(js, function(js){
     	    	res.end(js);
     	    });
-	    }
+	    });
 	});
 };

--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -272,12 +272,12 @@ HTTPSServer.prototype.exposeBundles = function(before, after){
 	var app = this.app || this;
 	exports.useBundles = true;
 	app.get("/bundle/:name.js", function(req, res){
-		before = before || function(cb){cb();};
-		after = after || function(v, cb){cb(v);};
-		before(function(){
-    	    var name = req.params.name || exports.name;
-    	    var js = app.exposed(name);
-    	    after(js, function(js){
+		var name = req.params.name || exports.name;
+		before = before || function(name, cb){cb();};
+		after = after || function(name, javascript, cb){cb(javascript);};
+		before(name, function(){
+    	    var javascript = app.exposed(name);
+    	    after(name, javascript, function(js){
     	    	res.end(js);
     	    });
 	    });

--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -1,4 +1,3 @@
-
 /*!
  * express-expose
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>
@@ -36,6 +35,8 @@ exports.namespace = 'express';
 
 exports.name = 'javascript';
 
+exports.useBundles = false;
+
 /**
  * Expose the given `obj` to the client-side, with
  * an optional `namespace` defaulting to "express".
@@ -51,7 +52,7 @@ res.expose =
 HTTPServer.prototype.expose =
 HTTPSServer.prototype.expose = function(obj, namespace, name){
   var app = this.app || this;
-
+  
   app._exposed = app._exposed || {};
 
   // support second arg as name
@@ -68,13 +69,20 @@ HTTPSServer.prototype.expose = function(obj, namespace, name){
     var helpers = {};
     app._exposed[name] = true;
     helpers[name] = function(req, res){
-      var appjs = app.exposed(name)
-        , resjs = res.exposed(name)
+      var resjs = res.exposed(name)
+        , appjs
         , js = '';
-
+      if(!exports.useBundles){
+        appjs = app.exposed(name);
+      }
+      
       if (appjs || resjs) {
-        js += '// app: \n' + appjs;
-        js += '// res: \n' + resjs;
+        if(exports.useBundles){
+          js += resjs;
+        } else {
+          js += '// app: \n' + appjs;
+          js += '// res: \n' + resjs;
+        }
       }
 
       return js;
@@ -258,3 +266,20 @@ function string(obj) {
     return JSON.stringify(obj);
   }
 }
+
+HTTPServer.prototype.exposeBundles =
+HTTPSServer.prototype.exposeBundles = function(before, after){
+	var app = this.app || this;
+	exports.useBundles = true;
+	app.get("/bundle/:name.js", function(req, res){
+		before = before || function(cb){cb();};
+		after = after || function(v, cb){cb(v);};
+		before(function(){
+    	    var name = req.params.name || exports.name;
+    	    var js = app.exposed(name);
+    	    after(js, function(js){
+    	    	res.end(js);
+    	    });
+	    }
+	});
+};


### PR DESCRIPTION
... at URLs which look like /bundle/:name.js where the default exposed items are at /bundle/javascript.js

To use this feature, just call app.exposeBundles();  It can be passed a function to call before (useful if you want to check a cache first) and a function to call after (useful for minification and saving to the cache).
