### PR TITLE
Make exposed a public api and provide a way of hiding application level exposes from the outputted JavaScript.

### DIFF
--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -1,4 +1,3 @@
-
 /*!
  * express-expose
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>
@@ -37,6 +36,11 @@ exports.namespace = 'express';
 exports.name = 'javascript';
 
 /**
+ * Default to exposing application level exposures as well as request level.
+ */
+exports.exposeAppLevel = true;
+
+/**
  * Expose the given `obj` to the client-side, with
  * an optional `namespace` defaulting to "express".
  *
@@ -68,7 +72,7 @@ HTTPSServer.prototype.expose = function(obj, namespace, name){
     var helpers = {};
     app._exposed[name] = true;
     helpers[name] = function(req, res){
-      var appjs = app.exposed(name)
+      var appjs = (exports.exposeAppLevel?app.exposed(name):'')
         , resjs = res.exposed(name)
         , js = '';
 
@@ -162,7 +166,7 @@ HTTPSServer.prototype.exposeModule = function(path, namespace, name){
  * Render the exposed javascript.
  *
  * @return {String}
- * @api private
+ * @api public
  */
 
 res.exposed =


### PR DESCRIPTION
This would allow writing plugins which cache the app level output in a separate file, to avoid loading it on every page request.
