### PR TITLE
Expose arrays as proper arrays even when they are top level.

### DIFF
--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -1,4 +1,3 @@
-
 /*!
  * express-expose
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>
@@ -97,6 +96,10 @@ HTTPSServer.prototype.expose = function(obj, namespace, name){
   } else if (this._require) {
     obj = 'module.exports = ' + string(obj);
     this.expose(renderRegister(namespace, obj), name);
+  // buffer array object
+  } else if (Array.isArray(obj)){
+    this.expose(renderArray(namespace, obj), name);
+    this.expose('\n');
   // buffer object
   } else {
     this.expose(renderNamespace(namespace), name);
@@ -216,6 +219,36 @@ function renderNamespace(str){
     parts.push(part);
     part = parts.join('.');
     return (i ? '' : 'window.') + part + ' = window.' + part + ' || {};';
+  }).join('\n');
+}
+
+/**
+ * Render an array from the given `str` and `arr`.
+ *
+ * Examples:
+ *
+ *    renderNamespace('foo.bar.baz', [1, 2, 3]);
+ *
+ *    var foo = foo || {};
+ *    foo.bar = foo.bar || {};
+ *    foo.bar.baz = foo.bar.baz || [1, 2, 3];
+ *
+ * @param {String} str
+ * @param {Array} arr
+ * @return {String}
+ * @api private
+ */
+
+function renderArray(str, arr){
+  var parts = []
+    , split = str.split('.')
+    , len = split.length;
+ 
+  return str.split('.').map(function(part, i){
+    parts.push(part);
+    part = parts.join('.');
+    if(i === len - 1) return (i ? '' : 'window.') + part + ' = ' + string(arr);
+    else return (i ? '' : 'window.') + part + ' = window.' + part + ' || {};';
   }).join('\n');
 }
 

--- a/test/express-expose.test.js
+++ b/test/express-expose.test.js
@@ -34,8 +34,8 @@ module.exports = {
     scope.express.settings.title.should.equal('My Site');
     scope.utils.add(1,5).should.equal(6);
     
-    Array.isArray(scope.empty).should.equal(true);
-    Array.isArray(scope.numbers).should.equal(true);
+    scope.empty.should.should.be.an.instanceof(Array);
+    scope.numbers.should.be.an.instanceof(Array);
     scope.empty.should.have.length(0);
     scope.numbers.should.have.length(3);
     scope.numbers[0].should.equal(1);

--- a/test/express-expose.test.js
+++ b/test/express-expose.test.js
@@ -36,8 +36,8 @@ module.exports = {
     
     Array.isArray(scope.empty).should.equal(true);
     Array.isArray(scope.numbers).should.equal(true);
-    scope.empty.lenght.should.equal(0);
-    scope.numbers.length.should.equal(3);
+    scope.empty.should.have.length(0);
+    scope.numbers.should.have.length(3);
     scope.numbers[0].should.equal(1);
     scope.numbers[1].should.equal(2);
     scope.numbers[2].should.equal(3);

--- a/test/express-expose.test.js
+++ b/test/express-expose.test.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -20,6 +19,8 @@ module.exports = {
     app.expose({ title: 'My Site' }, 'express.settings');
     app.expose({ add: function(a, b){ return a + b; } }, 'utils');
     app.expose({ en: 'English' }, 'langs', 'langs');
+    app.expose([], "empty");
+    app.expose([1,2,3], "numbers");
 
     var js = app.exposed()
       , scope = {};
@@ -32,6 +33,14 @@ module.exports = {
     
     scope.express.settings.title.should.equal('My Site');
     scope.utils.add(1,5).should.equal(6);
+    
+    Array.isArray(scope.empty).should.equal(true);
+    Array.isArray(scope.numbers).should.equal(true);
+    scope.empty.lenght.should.equal(0);
+    scope.numbers.length.should.equal(3);
+    scope.numbers[0].should.equal(1);
+    scope.numbers[1].should.equal(2);
+    scope.numbers[2].should.equal(3);
 
     var js = app.exposed('langs')
       , scope = {};


### PR DESCRIPTION
At the moment arrays become objects with indexes 0, 1, 2 etc.  This isn't helpful if you then need to do things like iterate over them.  This patch fixes that.
