### PR TITLE
Fix Request-Level exposure.

### DIFF
--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -56,38 +56,6 @@ app.expose = function(obj, namespace, name){
     namespace = namespace || exports.namespace;
   }
 
-  // locals
-  function locals(req, res) {
-    var appjs = app.exposed(name)
-      , resjs = res.exposed(name)
-      , js = '';
-
-    if (appjs || resjs) {
-      js += '// app: \n' + appjs;
-      js += '// res: \n' + resjs;
-    }
-
-    res.locals[name] = js;
-  }
-
-  // locals
-  
-  if (!app._exposed[name]) {
-    var helpers = {};
-    app._exposed[name] = true;
-
-    // request level
-    if (req) locals(req, this);
-
-    // app level
-    if (!req) {
-      app.use(function(req, res, next){
-        locals(req, res);
-        next();
-      });
-    }
-  }
-
   // buffer string
   if ('string' == typeof obj) {
     this.js = this.js || {};
@@ -104,6 +72,32 @@ app.expose = function(obj, namespace, name){
     this.expose(renderNamespace(namespace), name);
     this.expose(renderObject(obj, namespace), name);
     this.expose('\n');
+  }
+
+  // locals
+  function locals(req, res) {
+    var appjs = app.exposed(name)
+      , resjs = res.exposed(name)
+      , js = '';
+
+    if (appjs || resjs) {
+      js += '// app: \n' + appjs;
+      js += '// res: \n' + resjs;
+    }
+
+    res.locals[name] = js;
+  }
+  
+  // app level locals
+  if (!req && !app._exposed[name]) {
+    app._exposed[name] = true;
+    app.use(function(req, res, next){
+      locals(req, res);
+      next();
+    });
+  // request level locals
+  } else if (req) {
+    locals(req, this);
   }
 
   return this;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     , "mocha": "*"
     , "should": "*"
     , "jade": "*"
+    , "supertest": "*"
   }
   , "main": "index"
 }

--- a/test/express-expose.test.js
+++ b/test/express-expose.test.js
@@ -141,9 +141,11 @@ module.exports = {
     app.set('views', __dirname + '/views');
 
     app.expose('var user = { name: "tj" };')
+    app.expose('user.id = 50;')
 
     app.get('/', function(req, res) {
       res.expose('var lang = "en";');
+      res.expose('var country = "no";');
       res.render('index');
     });
 
@@ -155,6 +157,8 @@ module.exports = {
         var scope = {};
         vm.runInNewContext(res.text, scope);
         scope.user.name.should.equal('tj');
+        scope.user.id.should.equal(50);
+        scope.country.should.equal('no');
         scope.lang.should.equal('en');
         done();
       });


### PR DESCRIPTION
`locals` was only being called on the request level if something on the same namespace had not been previously exposed globally - and even then, it was being called before the value itself had been saved. I moved the `locals` call to after the values have been transformed/saved, and made sure it is called every time for request-level calls to `expose`. 

The only way around this would be to delay calling `locals` until right before the template is rendered. I couldn't see any obvious way of doing that.
