### PR TITLE
escape </script> in strings

### DIFF
--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -183,7 +183,7 @@ function string(obj) {
       return '"' + key + '":' + string(obj[key]);
     }).join(', ') + '}';
   } else {
-    return JSON.stringify(obj);
+    return JSON.stringify(obj).replace( /<\/script>/ig, '</scr"+"ipt>' );
   }
 }
 

--- a/lib/express-expose.js
+++ b/lib/express-expose.js
@@ -183,7 +183,9 @@ function string(obj) {
       return '"' + key + '":' + string(obj[key]);
     }).join(', ') + '}';
   } else {
-    return JSON.stringify(obj).replace( /<\/script>/ig, '</scr"+"ipt>' );
+    obj = JSON.stringify(obj);
+    if( obj ) obj = obj.replace( /<\/script>/ig, '</scr"+"ipt>' );
+    return obj;
   }
 }
 


### PR DESCRIPTION
If we don't keep the browser from misbehaving, this happens:
![Screen Shot 2013-03-21 at 5 51 46 PM](https://f.cloud.github.com/assets/507047/288907/d36d5f22-928a-11e2-8b9d-cc332e6ec37c.png)
...and we can't have that happen.

More on this issue here: http://stackoverflow.com/questions/8749001/escaping-html-entities-in-javascript-string-literals-within-the-script-block
